### PR TITLE
Fix WePay API endpoints in the Java SDK

### DIFF
--- a/src/com/lookfirst/wepay/WePayApi.java
+++ b/src/com/lookfirst/wepay/WePayApi.java
@@ -95,8 +95,8 @@ public class WePayApi {
 	}
 
 	/** */
-	private static final String STAGING_URL = "https://stage.wepay.com/v2";
-	private static final String PROD_URL = "https://wepay.com/v2";
+	private static final String STAGING_URL = "https://stage.wepayapi.com/v2/";
+	private static final String PROD_URL = "https://wepayapi.com/v2/";
 
 	/** */
 	private String currentUrl;


### PR DESCRIPTION
The API endpoints set in the SDK (STAGING_URL and PROD_URL) are not the correct endpoints for the API (see https://stage.wepay.com/developer/reference/endpoints). It won't affect anything for stage, but WePay 302 redirects all traffic to https://wepay.com to https://www.wepay.com to keep browser traffic on a consistent domain. Unfortunately, this means that API POST requests to https://wepay.com will get redirected and lose the POST body and any headers. Let me know if you have any questions about this and thanks for writing the Java SDK!
