### PR TITLE
Added all missing API states to Constants.State

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>WePay-Java-SDK</artifactId>
-	<version>2.0.2</version>
+	<version>2.0.3-SNAPSHOT</version>
 
 	<name>WePay-Java-SDK</name>
 	<description>WePay Java SDK</description>

--- a/src/main/java/com/lookfirst/wepay/api/Constants.java
+++ b/src/main/java/com/lookfirst/wepay/api/Constants.java
@@ -27,22 +27,40 @@ public class Constants {
 	 * Note that the toString() impls fix jackson serialization problems
 	 */
 	public static enum State {
-		new_ {
+		action_required {
 			@Override
-			public String toString() { return "new"; }
+			public String toString() { return "action required"; }
 		},
+		active,
+		approved,
 		authorized,
-		reserved,
-		captured,
-		settled,
+		available,
 		cancelled,
-		refunded,
+		captured,
 		charged_back {
 			@Override
 			public String toString() { return "charged back"; }
 		},
+		completed,
+		deleted,
+		disabled,
+		ended,
+		expired,
 		failed,
-		expired
+		invalid,
+		new_ {
+			@Override
+			public String toString() { return "new"; }
+		},
+		pending,
+		refunded,
+		registered,
+		reserved,
+		revoked,
+		settled,
+		started,
+		transition,
+		trial
 	}
 
 	public static enum FeePayer { payer, payee, payer_from_app, payee_from_app }


### PR DESCRIPTION
The latest WePayAPI (2014-01-08) has new states that are not accounted for and cause Jackson to blow up when trying to unmarshall JSON responses from WePay (such as /pre-approval/create).

`Constants.State` now represents the superset of all possible API object states for all endpoints.
