### PR TITLE
Added a missing (but required) parameter for programmatically registering users

### DIFF
--- a/src/main/java/com/lookfirst/wepay/api/req/UserRegisterRequest.java
+++ b/src/main/java/com/lookfirst/wepay/api/req/UserRegisterRequest.java
@@ -1,7 +1,5 @@
 package com.lookfirst.wepay.api.req;
 
-import java.util.Date;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 


### PR DESCRIPTION
WePay does not enforce the requiredness of this parameter in its staging environment, but it does in production so we need a way to set the value.
