### PR TITLE
Added missing constant for payment method type

### DIFF
--- a/src/main/java/com/lookfirst/wepay/api/Constants.java
+++ b/src/main/java/com/lookfirst/wepay/api/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
 
 	public static enum Mode { iframe, regular }
 	public static enum PaymentType { GOODS, SERVICE, DONATION, EVENT, PERSONAL }
+	public static enum PaymentMethodType { credit_card }
 	public static enum WithdrawalType { check, ach }
 
 	@Data


### PR DESCRIPTION
Currently only 'credit_card' is supported, but WePay may expand this in the future.
