### PR TITLE
Updates to SDK

### DIFF
--- a/src/main/java/com/lookfirst/wepay/WePayApi.java
+++ b/src/main/java/com/lookfirst/wepay/WePayApi.java
@@ -293,7 +293,7 @@ public class WePayApi {
 		if (postJson != null) {
 			conn.setDoOutput(true); // Triggers POST.
 		}
-		conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+		conn.setRequestProperty("Content-Type", "application/json");
 		conn.setRequestProperty("User-Agent", "WePay Java SDK");
 
 		if (token != null) {

--- a/src/main/java/com/lookfirst/wepay/api/AccountUri.java
+++ b/src/main/java/com/lookfirst/wepay/api/AccountUri.java
@@ -14,6 +14,6 @@ import lombok.EqualsAndHashCode;
 public class AccountUri extends AccountId {
 	private static final long serialVersionUID = 1L;
 
-	/** A uri that corresponds to the account's page on WePay. */
-	private String accountUri;
+	/** The URI to add or update info for the specified account id. */
+	private String uri;
 }

--- a/src/main/java/com/lookfirst/wepay/api/req/UserResendConfirmationRequest.java
+++ b/src/main/java/com/lookfirst/wepay/api/req/UserResendConfirmationRequest.java
@@ -10,8 +10,6 @@ import com.lookfirst.wepay.api.WePayUser;
  *
  * For users who were registered via the /user/register call, this API call lets you resend the API registration confirmation email.
  *
- * There are no arguments necessary for this call. Only an access token is required.
- *
  * @author Jon Scott Stevens
  * @author Jeff Schnitzer
  */
@@ -19,7 +17,9 @@ import com.lookfirst.wepay.api.WePayUser;
 @EqualsAndHashCode(callSuper=false)
 public class UserResendConfirmationRequest extends WePayRequest<WePayUser> {
 
-	/** */
+    /** A short message that will be included in the email to the user. */
+    private String emailMessage;
+
 	@Override
 	public String getEndpoint() {
 		return "/user/resend_confirmation";


### PR DESCRIPTION
Summary of changes: 
- Updated request and return structures to more closely resemble  current WePay API calls
- Removed the 'charset' designation the Content-Type request header, as this was causing a WePay call to fail. This is per discussion with engineering from WePay, as they suggest it should be removed.